### PR TITLE
Mobile help menu fixes

### DIFF
--- a/MobileApp/screens/Settings/HelpScreen.js
+++ b/MobileApp/screens/Settings/HelpScreen.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { View, Image, Dimensions, StyleSheet, Text } from 'react-native';
+import { View, Image, Dimensions, StyleSheet, Text, TouchableOpacity, Modal } from 'react-native';
 import Carousel from 'react-native-snap-carousel';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
@@ -19,13 +19,27 @@ const HelpScreen = () => {
 
   const carouselRef = useRef(null);
   const [activeSlide, setActiveSlide] = useState(0);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(null);
 
-  const renderItem = ({ item }) => {
+  const renderItem = ({ item, index }) => {
     return (
-      <View style={styles.carouselItem}>
-        <Image source={item} style={styles.image} />
-      </View>
+      <TouchableOpacity onPress={() => handleImagePress(index)}>
+        <View style={styles.carouselItem}>
+          <Image source={item} style={styles.image} />
+        </View>
+      </TouchableOpacity>
     );
+  };
+
+  const handleImagePress = (index) => {
+    setSelectedImageIndex(index);
+    setModalVisible(true);
+  };
+
+  const closeImageModal = () => {
+    setModalVisible(false);
+    setSelectedImageIndex(null);
   };
 
   const goToPreviousSlide = () => {
@@ -77,6 +91,20 @@ const HelpScreen = () => {
           onPress={goToNextSlide}
         />
       </View>
+      <Modal visible={modalVisible} transparent={true}>
+        <View style={styles.modalContainer}>
+          <Image source={manualImages[selectedImageIndex]} style={styles.modalImage} />
+          <Icon.Button
+            name="close"
+            size={40}
+            backgroundColor="transparent"
+            underlayColor="transparent"
+            color="#fff"
+            onPress={closeImageModal}
+            style={styles.closeButton}
+          />
+        </View>
+      </Modal>
     </View>
   );
 };
@@ -122,6 +150,22 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: 100,
     marginBottom: 50,
+  },
+  modalContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+  },
+  modalImage: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
+    resizeMode: 'contain',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 20,
+    right: 20,
   },
 });
 

--- a/MobileApp/screens/Settings/HelpScreen.js
+++ b/MobileApp/screens/Settings/HelpScreen.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { View, Image, Dimensions, StyleSheet, Text, TouchableOpacity, Modal } from 'react-native';
+import { View, Image, Dimensions, StyleSheet, Text, TouchableOpacity, Modal, SafeAreaView } from 'react-native';
 import Carousel from 'react-native-snap-carousel';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
@@ -54,6 +54,18 @@ const HelpScreen = () => {
     }
   };
 
+  const goToPreviousSlideInModal = () => {
+    if (selectedImageIndex > 0) {
+      setSelectedImageIndex(selectedImageIndex - 1);
+    }
+  };
+
+  const goToNextSlideInModal = () => {
+    if (selectedImageIndex < manualImages.length - 1) {
+      setSelectedImageIndex(selectedImageIndex + 1);
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.heading}>How to Use Pronto</Text>
@@ -94,15 +106,17 @@ const HelpScreen = () => {
       <Modal visible={modalVisible} transparent={true}>
         <View style={styles.modalContainer}>
           <Image source={manualImages[selectedImageIndex]} style={styles.modalImage} />
-          <Icon.Button
-            name="close"
-            size={40}
-            backgroundColor="transparent"
-            underlayColor="transparent"
-            color="#fff"
-            onPress={closeImageModal}
-            style={styles.closeButton}
-          />
+          <TouchableOpacity onPress={closeImageModal} style={styles.closeButton}>
+            <Icon name="close" size={40} color="#fff" />
+          </TouchableOpacity>
+          <View style={styles.modalNav}>
+            <TouchableOpacity onPress={goToPreviousSlideInModal}>
+              <Icon name="keyboard-arrow-left" size={40} color="#fff" style={{ paddingRight: 50 }} />
+            </TouchableOpacity>
+            <TouchableOpacity onPress={goToNextSlideInModal}>
+              <Icon name="keyboard-arrow-right" size={40} color="#fff" style={{ paddingLeft: 50 }} />
+            </TouchableOpacity>
+          </View>
         </View>
       </Modal>
     </View>
@@ -156,6 +170,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'rgba(0, 0, 0, 0.9)',
+
   },
   modalImage: {
     width: Dimensions.get('window').width,
@@ -164,9 +179,16 @@ const styles = StyleSheet.create({
   },
   closeButton: {
     position: 'absolute',
-    top: 20,
-    right: 20,
+    top: "10%",
+    right: "5%",
   },
+  modalNav: {
+    display: "flex",
+    flexDirection: "row",
+    position: 'absolute',
+    bottom: "10%",
+    right: "29%",
+  }
 });
 
 export default HelpScreen;


### PR DESCRIPTION
1. Added ability to increase size of help menu in mobile app when clicking on user manual

The images may have been too small for some users to view before, hence when the user clicks on one of the pages on the help menu, they will be shown this fullscreen version:

![simulator_screenshot_2294A1A9-98D2-48D6-815F-2196E85F99CE](https://github.com/COS301-SE-2023/Pronto/assets/101881243/36e3783c-f8fa-40ee-9b34-448c7ab312bb)
